### PR TITLE
Implement instantiate-args from @mhaberler commit 661cbc8

### DIFF
--- a/src/hal/icomp-example/plug.c
+++ b/src/hal/icomp-example/plug.c
@@ -73,8 +73,10 @@ static int export_halobjs(struct inst_data *ip, int owner_id, const char *name)
 }
 
 // constructor - init all HAL pins, params, funct etc here
-static int instantiate(const char *name, const int argc, const char**argv)
+static int instantiate(const int argc, const char**argv)
 {
+    // argv[0]: component name
+    const char *name = argv[1]; // instance name
     struct inst_data *ip;
 
     // allocate a named instance, and some HAL memory for the instance data

--- a/src/hal/lib/hal.h
+++ b/src/hal/lib/hal.h
@@ -266,7 +266,34 @@ enum comp_state {
     COMP_READY
 };
 
-typedef int (*hal_constructor_t) (const char *name, const int argc, const char**argv);
+// if a component exports a constructor via hal_export_xfunctf(), it is instantiable
+// the calling convention for hal_constructor_t is as follows:
+//
+// any instance parameters (key=value) up to the first appearance of '--' or a '--option' flag
+// are removed from the argument vector and are already applied
+// to the RTAPI_IP_* params when the constructor is called.
+//
+// the '--' separtor is skipped and not passed to the constructor.
+//
+// argv[0]: component name, string, always non-NULL
+// argv[1]: instance  name, string, always non-NULL
+// .. any other arguments ..
+//
+// other arguments are:
+// any argument passed after an '--' separator
+// any argument beginning with '--' (like a getopt_long() option)
+//
+// halcmd example 1: newinst foo bar instparm1=123 instparm2=3.14 --foo --bar baz key=value
+//
+// instance params = [instparm1=123, instparm2=3.14]
+// argv = [foo, bar, --foo, --bar, baz, key=value]
+// argc = 6
+//
+// halcmd example 2:  newinst foo bar -- instparm1=123 instparm2=3.14 --foo --bar baz key=value
+// no instparms are applied as all arguments follow the '--' separator
+// argv = [foo, bar, instparm1=123, instparm2=3.14, --foo, --bar, baz, key=value]
+// argc = 8
+typedef int (*hal_constructor_t) (const int argc, const char**argv);
 typedef int (*hal_destructor_t) (const char *name, void *inst, const int inst_size);
 
 // generic base function

--- a/src/hal/lib/hal_comp.c
+++ b/src/hal/lib/hal_comp.c
@@ -494,7 +494,7 @@ static int create_instance(const hal_funct_args_t *fa)
     if (inst) {
 	HALFAIL_RC(EBUSY,"instance '%s' already exists", iname);
     }
-    return comp->ctor(iname, argc - 2, &argv[2]);
+    return comp->ctor(argc, argv);
 }
 
 static int delete_instance(const hal_funct_args_t *fa)

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -647,7 +647,7 @@ def prologue(f):
             print >>f, "static int %s(void *arg, const hal_funct_args_t *fa);\n" % to_c(name)
         names[name] = 1
 
-    print >>f, "static int instantiate(const char *name, const int argc, const char**argv);\n"
+    print >>f, "static int instantiate(const int argc, const char**argv);\n"
     if options.get("extra_inst_cleanup"):
         print >>f, "static int delete(const char *name, void *inst, const int inst_size);\n"
     if options.get("extra_inst_setup") :
@@ -823,8 +823,10 @@ def prologue(f):
 ###########################  instantiate() ###############################################################
 
     print >>f, "\n// constructor - init all HAL pins, funct etc here"
-    print >>f, "static int instantiate(const char *name, const int argc, const char**argv)\n{"
+    print >>f, "static int instantiate(const int argc, const char**argv)\n{"
     print >>f, "struct inst_data *ip;"
+    print >>f, "// argv[0]: component name"
+    print >>f, "const char *name = argv[1];" # instance name
     print >>f, "int r;"
     if options.get("extra_inst_setup"):
         print >>f, "int k;"
@@ -867,10 +869,10 @@ def prologue(f):
         print >>f, "    if(k != 0)"
         print >>f, "        return k;\n"
 
-    print >>f, "    if(r == 0)"
-    print >>f, "        hal_print_msg(RTAPI_MSG_DBG,\"%s - instance %s creation SUCCESSFUL\",__FUNCTION__, name);"
-    print >>f, "    else"
-    print >>f, "        hal_print_msg(RTAPI_MSG_DBG,\"%s - instance %s creation ABORTED\",__FUNCTION__, name);"
+    #print >>f, "    if(r == 0)"
+    #print >>f, "        hal_print_msg(RTAPI_MSG_DBG,\"%s - instance %s creation SUCCESSFUL\",__FUNCTION__, name);"
+    #print >>f, "    else"
+    #print >>f, "        hal_print_msg(RTAPI_MSG_DBG,\"%s - instance %s creation ABORTED\",__FUNCTION__, name);"
     if have_count:
         print >>f, "//reset pincount to -1 so that instantiation without it will result in DEFAULTCOUNT"
         print >>f, "    pincount = -1;\n"


### PR DESCRIPTION
Change instantiation API so that argc/argv hold all info

instantiate() now gets the name from argv[0]
All demos and instcomp code altered to implement.

When calling `newinst`, all args after a `--` delimiter are passed to the
component being called, without being processed and are available
for use within the component from the **argv passed to it.

Signed-off-by: Mick <arceye@mgware.co.uk>