### PR TITLE
Fix tests/hm2_idrom

### DIFF
--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -537,6 +537,8 @@ typedef struct hal_funct_args {
     hal_thread_t  *thread; // descriptor of invoking thread, NULL with FS_USERLAND
     hal_funct_t   *funct;  // descriptor of invoked funct
 
+    long actual_period;  // actually measured
+
     // argument vector for FS_USERLAND; 0/NULL for others
     int argc;
     const char **argv;
@@ -636,6 +638,14 @@ static inline long fa_period(const hal_funct_args_t *fa)
     if (fa->thread)
 	return fa->thread->period;
     return 0;
+}
+
+// actually measured thread period in nS, relative to last invocation
+// on first call, will expose the nominal period, measured times thereafter
+// addresses https://github.com/machinekit/machinekit/issues/657
+static inline long fa_actual_period(const hal_funct_args_t *fa)
+{
+    return fa->actual_period;
 }
 
 // the actual invocation period including jitter

--- a/src/hal/lib/hal_thread.c
+++ b/src/hal/lib/hal_thread.c
@@ -45,6 +45,8 @@ static void thread_task(void *arg)
 	    // expose current invocation period as pin (includes jitter)
 	    act_period = fa.start_time - fa.last_start_time;
 	    set_s32_pin(thread->curr_period, act_period);
+	    // keep hostmot2 going
+	    fa.actual_period = fa.thread_start_time - fa.last_start_time;
 
 	    fa.last_start_time = fa.thread_start_time = fa.start_time;
 

--- a/tests/hm2-idrom/skip
+++ b/tests/hm2-idrom/skip
@@ -4,4 +4,4 @@
 # Skip the hm2-idrom test if not running kernel threads and the
 # hostmot2.so module doesn't exist for this flavor
 
-test "$(flavor -b)" = kbuild -a -f $EMC2_HOME/rtlib/$(flavor)/hostmot2.so
+test "$(flavor -b)" = kbuild -o -f $EMC2_HOME/rtlib/$(flavor)/hostmot2.so


### PR DESCRIPTION
These tests failed and discovered that an inline function `fa_actual_period`
used by hostmot2, was missing from hal_priv.h

Likewise the updating of the value in the fa struct was missing from
hal_thread.c

This prevented hostmot2 from loading and would have meant that no Mesa
based configs would have worked.

Signed-off-by: Mick <arceye@mgware.co.uk>