### PR TITLE
Fix Mesa card failing to produce step pulses

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -77,7 +77,7 @@ static int comp_id;
 
 static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
     hostmot2_t *hm2 = void_hm2;
-    long period = fa_actual_period(fa);
+    long period = fa_current_period(fa);
 
     // if there are comm problems, wait for the user to fix it
     if ((*hm2->llio->io_error) != 0) return -1;
@@ -104,7 +104,7 @@ static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
 
 static int hm2_write(void *void_hm2, const hal_funct_args_t *fa) {
     hostmot2_t *hm2 = void_hm2;
-    long period = fa_actual_period(fa);
+    long period = fa_current_period(fa);
 
     // if there are comm problems, wait for the user to fix it
     if ((*hm2->llio->io_error) != 0) return -1;
@@ -151,7 +151,7 @@ static int hm2_read_gpio(void *void_hm2, const hal_funct_args_t *fa) {
 
 static int hm2_write_gpio(void *void_hm2, const hal_funct_args_t *fa) {
     hostmot2_t *hm2 = void_hm2;
-    long period = fa_actual_period(fa);
+    long period = fa_current_period(fa);
 
     // if there are comm problems, wait for the user to fix it
     if ((*hm2->llio->io_error) != 0) return -1;

--- a/src/hal/i_components/period.icomp
+++ b/src/hal/i_components/period.icomp
@@ -9,6 +9,6 @@ license "GPL";
 FUNCTION(_)
 {
     period_ns = (hal_float_t) fa_period(fa);
-    actual_period_ns = (hal_float_t)fa_actual_period(fa);
+    actual_period_ns = (hal_float_t)fa_current_period(fa);
     return 0;
 }

--- a/src/hal/lib/hal_priv.h
+++ b/src/hal/lib/hal_priv.h
@@ -537,8 +537,6 @@ typedef struct hal_funct_args {
     hal_thread_t  *thread; // descriptor of invoking thread, NULL with FS_USERLAND
     hal_funct_t   *funct;  // descriptor of invoked funct
 
-    long actual_period;  // actually measured
-
     // argument vector for FS_USERLAND; 0/NULL for others
     int argc;
     const char **argv;
@@ -640,15 +638,7 @@ static inline long fa_period(const hal_funct_args_t *fa)
     return 0;
 }
 
-// actually measured thread period in nS, relative to last invocation
-// on first call, will expose the nominal period, measured times thereafter
-// addresses https://github.com/machinekit/machinekit/issues/657
-static inline long fa_actual_period(const hal_funct_args_t *fa)
-{
-    return fa->actual_period;
-}
-
-// the actual invocation period including jitter
+// the actual invocation period including jitter - replaces fa_actual_period()
 static inline const hal_s32_t get_s32_pin(const s32_pin_ptr p);
 static inline hal_s32_t fa_current_period(const hal_funct_args_t *fa)
 {

--- a/src/hal/lib/hal_thread.c
+++ b/src/hal/lib/hal_thread.c
@@ -45,8 +45,6 @@ static void thread_task(void *arg)
 	    // expose current invocation period as pin (includes jitter)
 	    act_period = fa.start_time - fa.last_start_time;
 	    set_s32_pin(thread->curr_period, act_period);
-	    // keep hostmot2 going
-	    fa.actual_period = fa.thread_start_time - fa.last_start_time;
 
 	    fa.last_start_time = fa.thread_start_time = fa.start_time;
 


### PR DESCRIPTION
fa_actual_period accesses a member of the `hal_funct_args_t` struct and is used
in the existing (machinekit/master) hostmot2 code to get the thread period

Multicore changed the handling of threads and how all the thread periods
were calculated
fa_current_period which accesses a member of `hal_thread_t` via accessors
provides the same functionality

hostmot2 changed to use this function and tested to work on Mesa 5i25/7i76

One component that uses same call also amended and most of <fe6787e>
reverted.  tests/hm2_idrom tested and works too.

Signed-off-by: Mick <arceye@mgware.co.uk>