### PR TITLE
Preliminary changes to get hm2_soc_ol loading

### DIFF
--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -348,7 +348,7 @@ static int do_kmodinst_args(const string &comp,
 			param_name.c_str());
 	    return -ENOENT;
 	}
-	int retval = procfs_cmd(path.c_str(), param_value.c_str());
+	int retval = rtapi_fs_write(path.c_str(), param_value.c_str());
 	if (retval < 0) {
 	    note_printf(pbreply, "newinst %s: setting param %s to %s failed:  %d - %s",
 			comp.c_str(),
@@ -447,7 +447,7 @@ static int do_newinst_cmd(int instance,
 	string s = pbconcat(args);
 	retval = do_kmodinst_args(comp,args,pbreply);
 	if (retval) return retval;
-	return procfs_cmd(PROCFS_RTAPICMD,"call newinst %s %s %s",
+	return rtapi_fs_write(PROCFS_RTAPICMD,"call newinst %s %s %s",
 			  comp.c_str(),
 			  instname.c_str(),
 			  s.c_str());
@@ -521,7 +521,7 @@ static int do_delinst_cmd(int instance,
 
 
     if (kernel_threads(flavor)) {
-	return procfs_cmd(PROCFS_RTAPICMD,"call delinst %s", instname.c_str());
+	return rtapi_fs_write(PROCFS_RTAPICMD,"call delinst %s", instname.c_str());
     } else {
 	if (call_usrfunct == NULL) {
 	    pbreply.set_retcode(1);
@@ -549,7 +549,7 @@ static int do_callfunc_cmd(int instance,
 
     if (kernel_threads(flavor)) {
 	string s = pbconcat(args);
-	return procfs_cmd(PROCFS_RTAPICMD,"call %s %s", func.c_str(), s.c_str());
+	return rtapi_fs_write(PROCFS_RTAPICMD,"call %s %s", func.c_str(), s.c_str());
     } else {
 	if (call_usrfunct == NULL) {
 	    pbreply.set_retcode(1);
@@ -942,7 +942,7 @@ static int rtapi_request(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 	assert(pbreq.rtapicmd().has_flags());
 
 	if (kernel_threads(flavor)) {
-	    int retval =  procfs_cmd(PROCFS_RTAPICMD,"newthread %s %d %d %d %d",
+	    int retval =  rtapi_fs_write(PROCFS_RTAPICMD,"newthread %s %d %d %d %d",
 				     pbreq.rtapicmd().threadname().c_str(),
 				     pbreq.rtapicmd().threadperiod(),
 				     pbreq.rtapicmd().use_fp(),
@@ -986,7 +986,7 @@ static int rtapi_request(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 	assert(pbreq.rtapicmd().has_instance());
 
 	if (kernel_threads(flavor)) {
-	    int retval =  procfs_cmd(PROCFS_RTAPICMD, "delthread %s",
+	    int retval =  rtapi_fs_write(PROCFS_RTAPICMD, "delthread %s",
 					   pbreq.rtapicmd().threadname().c_str());
 	    pbreply.set_retcode(retval < 0 ? retval:0);
 	} else {

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -37,6 +37,8 @@
 #include <stdlib.h>		/* exit() */
 #include <string.h>		/* exit() */
 #include <grp.h>                // getgroups
+#include <spawn.h>              // posix_spawn
+#include <sys/wait.h>           // wait_pid
 
 #include <elf.h>                // get_rpath()
 #include <link.h>
@@ -473,7 +475,9 @@ int run_module_helper(const char *format, ...)
     return system(mod_helper);
 }
 
-int procfs_cmd(const char *path, const char *format, ...)
+//int procfs_cmd(const char *path, const char *format, ...)
+// whatever is written is printf-style
+int rtapi_fs_write(const char *path, const char *format, ...)
 {
     va_list args;
     int fd;
@@ -490,6 +494,33 @@ int procfs_cmd(const char *path, const char *format, ...)
 	return retval;
     } else
 	return -ENOENT;
+}
+
+// filename is printf-style
+int rtapi_fs_read(char *buf, const size_t maxlen, const char *name, ...)
+{
+    char fname[4096];
+    va_list args;
+
+    va_start(args, name);
+    size_t len = vsnprintf(fname, sizeof(fname), name, args);
+    va_end(args);
+
+    if (len < 1)
+    return -EINVAL; // name too short
+
+    int fd, rc;
+    if ((fd = open(fname, O_RDONLY)) >= 0) {
+    rc = read(fd, buf, maxlen);
+    close(fd);
+    if (rc < 0)
+        return -errno;
+    char *s = strchr(buf, '\n');
+    if (s) *s = '\0';
+    return strlen(buf);
+    } else {
+    return -errno;
+    }
 }
 
 const char *rtapi_get_rpath(void)
@@ -528,6 +559,7 @@ int get_elf_section(const char *const fname, const char *section_name, void **de
     char *p = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (p == NULL) {
 	perror("mmap");
+    close(fd);
 	return -1;
     }
 
@@ -683,3 +715,42 @@ int rtapi_get_tags(const char *mod_name)
     free(caps);
     return result;
 }
+
+// lifted from hm2_ether.c by Michael Geszkiewicz  and Jeff Epler
+int run_shell(char *format, ...)
+{
+    char command[PATH_MAX];
+    va_list args;
+    int retval;
+
+    va_start(args, format);
+    retval = vsnprintf(command, sizeof(command), format, args);
+    va_end(args);
+
+    if (retval < 0) {
+    perror("vsnprintf");
+    return retval;
+    }
+    char *const argv[] = {"sh", "-c", command, NULL};
+    pid_t pid;
+    retval = posix_spawn(&pid, "/bin/sh", NULL, NULL, argv, environ);
+    if(retval < 0)
+    perror("posix_spawn");
+
+    int status;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status))
+    return WEXITSTATUS(status);
+    else if (WIFSTOPPED(status))
+    return WTERMSIG(status)+128;
+    else
+    return status;
+}
+
+// those are ok to use from userland RT modules:
+#if defined(BUILD_SYS_USER_DSO) && defined(RTAPI)
+EXPORT_SYMBOL(run_shell);
+EXPORT_SYMBOL(is_module_loaded);
+EXPORT_SYMBOL(rtapi_fs_read);
+EXPORT_SYMBOL(rtapi_fs_write);
+#endif

--- a/src/rtapi/rtapi_compat.h
+++ b/src/rtapi/rtapi_compat.h
@@ -99,7 +99,21 @@ extern long int simple_strtol(const char *nptr, char **endptr, int base);
 // HAL return values are reflected in the return value to write()
 //
 #define PROCFS_RTAPICMD "/proc/rtapi/hal/rtapicmd"
-extern int procfs_cmd(const char *path, const char *format, ...);
+
+// whatever is written is printf-style
+int rtapi_fs_write(const char *path, const char *format, ...);
+
+// read a string from a sysfs entry.
+// strip trailing newline.
+// returns length of string read (>= 0)
+// or <0: -errno from open or read.
+// filename is printf-style
+int rtapi_fs_read(char *buf, const size_t maxlen, const char *name, ...);
+
+
+int run_shell(char *format, ...);
+
+//extern int procfs_cmd(const char *path, const char *format, ...);
 
 // kernel tests in rtapi_compat.c
 extern int kernel_is_xenomai();


### PR DESCRIPTION
hm2_soc_ol requires rtapi_fs_read() which is not implemented

It also uses procfs_cmd() which is superceeded by rtapi_fs_write()

This is not a fix of the DE0-NANO-Soc problem, just fixes some stuff
so that testing can be done

Signed-off-by: Mick <arceye@mgware.co.uk>