### PR TITLE
hostmot2: Fix rtapi_print_hex_dump crash

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/fwid.c
+++ b/src/hal/drivers/mesa-hostmot2/fwid.c
@@ -85,7 +85,7 @@ int hm2_fwid_parse_md(hostmot2_t *hm2, int md_index) {
 	// starts right after the uint32-sized size field
 	hm2->llio->read(hm2->llio, addr + 8, buf, alignedsize);
 	rtapi_print_hex_dump(RTAPI_MSG_DBG, RTAPI_DUMP_PREFIX_OFFSET,
-			     16, 1, (const void *)buf, rawsize, 1,
+			     16, 1, (const void *)buf, rawsize, 1, NULL,
 			     "fwid msg at %p:", buf);
     } else {
 	alignedsize = rawsize = hm2->llio->fwid_len; // override msg was passed

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -365,7 +365,7 @@ static int hm2_soc_mmap(hm2_soc_t *brd) {
 
     if (debug)
 	rtapi_print_hex_dump(RTAPI_MSG_INFO, RTAPI_DUMP_PREFIX_OFFSET,
-			     16, 1, (const void *)virtual_base, 4096, 1,
+			     16, 1, (const void *)virtual_base, 4096, 1, NULL,
 			     "hm2 regs at %p:", virtual_base);
 
     // this duplicates stuff already happening in hm2_register - no harm


### PR DESCRIPTION
A simple solution to a complex problem.  The rtapi_print_hex_dump
function should probably be refactored to allow for printing into a
buffer rather than passing around raw pointers to vsnprintf() style
functions.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>